### PR TITLE
Improve 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,5 @@
+---
+layout: page
+title: 404
+description: Page not found
+---

--- a/404.html
+++ b/404.html
@@ -2,4 +2,5 @@
 layout: page
 title: 404
 description: Page not found
+permalink: /404.html
 ---

--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ matter. Example:
     repository](https://github.com/btc-raspberrypiclub/cleaner-blog-jekyll) to
     see how the files are set up.
 
+5. Create `404.html` if it doesn't already exist, and modify the front matter.
+    
+    ```markdown
+    ---
+    layout: page
+    title: 404
+    description: Page not found
+    permalink: /404.html
+    ---
+    ```
+
 <!-- TODO:
 
 5. Add the form to the `contact.html` page. Add the following code to your
@@ -148,7 +159,7 @@ matter. Example:
     Formspree, and then the form will be working!
 -->
 
-5. Build your site: `bundle exec jekyll serve`
+6. Build your site: `bundle exec jekyll serve`
 
 ### Using Core Files
 

--- a/jekyll-theme-cleaner-blog.gemspec
+++ b/jekyll-theme-cleaner-blog.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/btc-raspberrypiclub/cleaner-blog-jekyll'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|_layouts|_includes|_sass|LICENSE|README)}i) }
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|_layouts|_includes|_sass|LICENSE|README|404.html)}i) }
 
   # TODO: Might be outdated
   spec.add_runtime_dependency 'jekyll', '>= 3.8.5'


### PR DESCRIPTION
This PR adds a `404.html` page, but that will not show up on a site that uses this theme, so it also adds a step in the README where the user can add a `404` page